### PR TITLE
possibility to display flash alerts when resource is invalid

### DIFF
--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -9,6 +9,8 @@ module Wicked::Controller::Concerns::RenderRedirect
       url_params = (@wicked_redirect_params || {}).merge(params)
       redirect_to wizard_path(@skip_to, url_params), options
     else
+      flash[:alert] = resource.errors.full_messages.join(', ') if options[:show_alerts] && resource.errors.any?
+
       render_step(wizard_value(step), options, params)
     end
   end


### PR DESCRIPTION
Hi,
I'm missing flash alert messages when the resource model becomes invalid in the middle of the wizard.

it could be done by a change similar to the one below (and triggered by `render_wizard @model, show_alerts: true`)

I'd like to start a discussion about the feature and its implementation. what do you think?

thanks!