### PR TITLE
Use strong parameters in example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,16 @@ class AfterSignupController < ApplicationController
     @user = current_user
     case step
     when :confirm_password
-      @user.update_attributes(params[:user])
+      @user.update_attributes(user_params)
     end
     sign_in(@user, bypass: true) # needed for devise
     render_wizard @user
+  end
+  
+  private
+  def user_params
+    params.require(:user)
+          .permit(:email, :current_password) # ...
   end
 end
 ```


### PR DESCRIPTION
Strong params have been in core since Rails 4. Its probably high time for an example that does not raise a ForbiddenAttributes error.