### PR TITLE
Adding HTTP Status Code for failed #update action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Update readme to include `current_step?` (https://github.com/zombocom/wicked/pull/271)
+* Add `:status` field to response options and default to `:unprocessable_entity / 422` when model update fails. (https://github.com/zombocom/wicked/pull/267)
 
 ## 1.3.4
 

--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -25,6 +25,8 @@ module Wicked::Controller::Concerns::RenderRedirect
       @skip_to ||= @next_step
     else
       @skip_to = nil
+      # Do not override user-provided status for render
+      options[:status] ||= :unprocessable_entity
     end
   end
 

--- a/test/controllers/status_codes_controller_test.rb
+++ b/test/controllers/status_codes_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class StatusCodesControllerTest < WickedControllerTestCase
+  test 'returns successful status code for show' do 
+    get :show, params: {:id => 'good'}
+    assert_response(:success)
+  end
+
+  test 'returns correct status code for successfuly update' do 
+    put :update, params: {:id => 'good'}
+    assert_response(:redirect)
+  end
+
+  test 'returns correct status code for failed update' do 
+    put :update, params: {:id => 'bad'}
+    assert_response(:unprocessable_entity)
+  end
+
+end

--- a/test/dummy/app/controllers/status_codes_controller.rb
+++ b/test/dummy/app/controllers/status_codes_controller.rb
@@ -1,0 +1,41 @@
+class StatusCodesController < ApplicationController
+  include Wicked::Wizard
+
+  class GoodThing
+    def save
+      true
+    end
+  end
+
+  class BadThing
+    def save
+      false
+    end
+  end
+
+  steps :good, :bad
+
+  def index
+
+  end
+
+  def show
+    render_wizard
+  end
+
+  def update
+    case step
+    when :good 
+      @thing = GoodThing.new
+    when :bad
+      @thing = BadThing.new
+    end
+    render_wizard(@thing, notice: "Thing was updated from step #{step}.")
+  end
+
+  private
+
+  def finish_wizard_path
+    updates_path
+  end
+end

--- a/test/dummy/app/views/status_codes/bad.html.erb
+++ b/test/dummy/app/views/status_codes/bad.html.erb
@@ -1,0 +1,1 @@
+bad step

--- a/test/dummy/app/views/status_codes/good.html.erb
+++ b/test/dummy/app/views/status_codes/good.html.erb
@@ -1,0 +1,1 @@
+good step

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -8,6 +8,7 @@ Dummy::Application.routes.draw do
   resources :string_steps
   resources :redirect_to_next
   resources :redirect_to_finish_flash
+  resources :status_codes
   resources :updates
   resources :update_params
 


### PR DESCRIPTION
Hi. I noticed the HTTP status code for failed Update returns a 200 by default. This is fine in practice, but would be great to include 422 for those of us using status codes as an indicator for tests & functionality. Let me know, and thanks for the great project!