### PR TITLE
Add current_step? to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ test/dummy/log/*.log
 test/dummy/tmp/
 .DS_Store
 .rvmrc
+.idea
 
 Gemfile.lock
 .ruby-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Update readme to include `current_step?` (https://github.com/zombocom/wicked/pull/271)
+
 ## 1.3.4
 
 * Remove arity check for AR objects (https://github.com/schneems/wicked/pull/257)

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ render_wizard                                 # Renders the current step
 render_wizard(@user)                          # Shows next_step if @user.save, otherwise renders
 render_wizard(@user, context: :account_setup) # Shows next_step if @user.save(context: :account_setup), otherwise renders
 wizard_steps                                  # Gets ordered list of steps
+current_step?(step)                           # is step the same as the current request's step
 past_step?(step)                              # does step come before the current request's step in wizard_steps
 future_step?(step)                            # does step come after the current request's step in wizard_steps
 previous_step?(step)                          # is step immediately before the current request's step


### PR DESCRIPTION
The `current_step?` helper method already exists but it wasn't listed in the documentation so this PR adds it.

P.S. Thanks so much for creating this gem @schneems. We have used it several times already and it is fantastic.