### PR TITLE
add fully qualified versions of wizard path helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Update readme to include `current_step?` (https://github.com/zombocom/wicked/pull/271)
+* Add `*_url` versions of `wizard_path`, `next_wizard_path`, and `previous_wizard_path` (https://github.com/zombocom/wicked/pull/272)
 
 ## 1.3.4
 

--- a/README.md
+++ b/README.md
@@ -177,12 +177,17 @@ Now you've got a fully functioning AfterSignup controller! If you have questions
 **View/URL Helpers:**
 
 ```ruby
-wizard_path                  # Grabs the current path in the wizard
-wizard_path(:specific_step)  # Url of the :specific_step
-next_wizard_path             # Url of the next step
-previous_wizard_path         # Url of the previous step
+wizard_path                  # relative url of the current step
+wizard_path(:specific_step)  # relative url of a :specific_step
+next_wizard_path             # relative url of the next step
+previous_wizard_path         # relative url of the previous step
 
-# These only work while in a Wizard, and are not absolute paths
+wizard_url                  # fully qualified url of the current step
+wizard_url(:specific_step)  # fully qualified url of a :specific_step
+next_wizard_url             # fully qualified url of the next step
+previous_wizard_url         # fully qualified url of the previous step
+
+# These only work while in a Wizard
 # You can have multiple wizards in a project with multiple `wizard_path` calls
 ```
 

--- a/lib/wicked/controller/concerns/path.rb
+++ b/lib/wicked/controller/concerns/path.rb
@@ -5,8 +5,16 @@ module Wicked::Controller::Concerns::Path
     wizard_path(@next_step, options)
   end
 
+  def next_wizard_url(options = {})
+    wizard_url(@next_step, options)
+  end
+
   def previous_wizard_path(options = {})
     wizard_path(@previous_step, options)
+  end
+
+  def previous_wizard_url(options = {})
+    wizard_url(@previous_step, options)
   end
 
   def wicked_controller
@@ -25,5 +33,9 @@ module Wicked::Controller::Concerns::Path
                 :only_path  => true
                }.merge options
     url_for(options)
+  end
+
+  def wizard_url(goto_step = nil, options = {})
+    wizard_path(goto_step, options.merge(only_path: false))
   end
 end

--- a/lib/wicked/wizard.rb
+++ b/lib/wicked/wizard.rb
@@ -22,10 +22,10 @@ module Wicked
     included do
       include Wicked::Controller::Concerns::Action
       # Give our Views helper methods!
-      helper_method :wizard_path,     :next_wizard_path, :previous_wizard_path,
-                    :step,            :wizard_steps,     :current_step?,
-                    :past_step?,      :future_step?,     :previous_step?,
-                    :next_step?
+      helper_method :wizard_path, :wizard_url, :next_wizard_path, :next_wizard_url, :previous_wizard_path,
+                    :previous_wizard_url, :step, :wizard_steps, :current_step?, :past_step?, :future_step?,
+                    :next_step?,  :previous_step?
+
       # Set @step and @next_step variables
       before_action :initialize_wicked_variables, :setup_wizard
     end

--- a/test/dummy/app/views/bar/first.html.erb
+++ b/test/dummy/app/views/bar/first.html.erb
@@ -4,4 +4,6 @@ first
 <%= "params[:foo] #{params[:foo]}" %>
 <%= link_to 'last', wizard_path(:last_step) %>
 <%= link_to 'current', wizard_path %>
+<%= link_to 'current url', wizard_url %>
 <%= link_to 'skip', next_wizard_path %>
+<%= link_to 'next url', next_wizard_url %>

--- a/test/dummy/app/views/bar/second.html.erb
+++ b/test/dummy/app/views/bar/second.html.erb
@@ -1,3 +1,4 @@
 second
 
 <%= link_to 'previous', previous_wizard_path %>
+<%= link_to 'previous url', previous_wizard_url %>

--- a/test/integration/helpers_test.rb
+++ b/test/integration/helpers_test.rb
@@ -5,13 +5,23 @@ class HelpersTest < ActiveSupport::IntegrationCase
   test 'next_wizard_path' do
     step = :first
     visit(bar_path(step))
+    assert has_link?('skip', href: '/bar/second')
     click_link 'skip'
+    assert_has_content?('second')
+  end
+
+  test 'next_wizard_url' do
+    step = :first
+    visit(bar_path(step))
+    assert has_link?('next url', href: 'http://www.example.com/bar/second')
+    click_link 'next url'
     assert_has_content?('second')
   end
 
   test 'wizard_path' do
     step = :first
     visit(bar_path(step))
+    assert has_link?('current', href: '/bar/first')
     click_link 'current'
     assert_has_content?(step.to_s)
   end
@@ -23,9 +33,26 @@ class HelpersTest < ActiveSupport::IntegrationCase
     assert_has_content?('last_step')
   end
 
+  test 'wizard_url' do
+    step = :first
+    visit(bar_path(step))
+    assert has_link?('current url', href: 'http://www.example.com/bar/first')
+    click_link 'current'
+    assert_has_content?(step.to_s)
+  end
+
   test 'previous_wizard_path' do
     step = :second
     visit(bar_path(step))
+    assert has_link?('previous', href: '/bar/first')
+    click_link 'previous'
+    assert_has_content?("first")
+  end
+
+  test 'previous_wizard_url' do
+    step = :second
+    visit(bar_path(step))
+    assert has_link?('previous url', href: 'http://www.example.com/bar/first')
     click_link 'previous'
     assert_has_content?("first")
   end


### PR DESCRIPTION
This PR adds `*_url` versions of `wizard_path`, `next_wizard_path`, and `previous_wizard_path`. 

There are a few reasons we would like to see this in the gem:

First, it brings the wizard route helpers into alignment with Rails convention which offers both `*_path` and `*_url` helpers.

Second, it also allows us to honor the HTTP spec which says that [all redirects should be fully qualified](https://www.viget.com/articles/rails-named-routes-path-vs-url). 

Finally, our wizards involve a user signing in or creating an account and we use a Single Sign On solution for that which requires redirecting out to a different app and then getting redirected back. We need to pass a fully qualified url to the SSO app so that it can return the user to us correctly. We have created this in our own controller so we aren't blocked but it would be nice if the gem provided them.