### PR TITLE
Return 422 - :unprocessable_entity when form submissions fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Return `422` (`:unprocessable_entity`) when form submissions fails (https://github.com/zombocom/wicked/pull/294)
+* Return `422` (`:unprocessable_entity`) when form submissions fails. Turbo requires an HTTP Status code between 400-499 or 500-599 when a FormSubmission request fails. This pull request makes wicked compatible with Turbo Drive (https://github.com/zombocom/wicked/pull/294)
 * Pass the provided step when raising InvalidStepError errors (https://github.com/zombocom/wicked/pull/284)
 
 ## 1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Return `422` (`:unprocessable_entity`) when form submissions fails (https://github.com/zombocom/wicked/pull/294)
 * Pass the provided step when raising InvalidStepError errors (https://github.com/zombocom/wicked/pull/284)
 
 ## 1.4.0

--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -25,6 +25,8 @@ module Wicked::Controller::Concerns::RenderRedirect
       @skip_to ||= @next_step
     else
       @skip_to = nil
+      # Do not override user-provided status for render
+      options[:status] ||= :unprocessable_entity
     end
   end
 

--- a/test/controllers/status_codes_controller_test.rb
+++ b/test/controllers/status_codes_controller_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class StatusCodesControllerTest < WickedControllerTestCase
+  test 'returns successful status code for show' do
+    get :show, params: { id: 'good' }
+    assert_response(:success)
+  end
+
+  test 'returns correct status code for successfuly update' do
+    put :update, params: { id: 'good' }
+    assert_response(:redirect)
+  end
+
+  test 'returns correct status code for failed update' do
+    put :update, params: { id: 'bad' }
+    assert_response(:unprocessable_entity)
+  end
+end

--- a/test/dummy/app/controllers/status_codes_controller.rb
+++ b/test/dummy/app/controllers/status_codes_controller.rb
@@ -1,0 +1,39 @@
+class StatusCodesController < ApplicationController
+  include Wicked::Wizard
+
+  class GoodThing
+    def save
+      true
+    end
+  end
+
+  class BadThing
+    def save
+      false
+    end
+  end
+
+  steps :good, :bad
+
+  def index; end
+
+  def show
+    render_wizard
+  end
+
+  def update
+    case step
+    when :good
+      @thing = GoodThing.new
+    when :bad
+      @thing = BadThing.new
+    end
+    render_wizard(@thing, notice: "Thing was updated from step #{step}.")
+  end
+
+  private
+
+  def finish_wizard_path
+    updates_path
+  end
+end

--- a/test/dummy/app/views/status_codes/bad.html.erb
+++ b/test/dummy/app/views/status_codes/bad.html.erb
@@ -1,0 +1,1 @@
+bad step

--- a/test/dummy/app/views/status_codes/good.html.erb
+++ b/test/dummy/app/views/status_codes/good.html.erb
@@ -1,0 +1,1 @@
+good step

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -8,6 +8,7 @@ Dummy::Application.routes.draw do
   resources :string_steps
   resources :redirect_to_next
   resources :redirect_to_finish_flash
+  resources :status_codes
   resources :updates
   resources :update_params
 


### PR DESCRIPTION
Fixes #278

Turbo requires an HTTP Status code between 400-499 or 500-599 when a FormSubmission request fails 
(e.g. [unprocessable entity](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422)).
This pull request makes wicked compatible with Turbo Drive.

For more details refer this pull request on rails: https://github.com/rails/rails/pull/41026

This is an old pull request from @romanos - #267
Rebased and made some formatting changes

<img width="788" alt="Screenshot 2022-09-14 at 11 42 13" src="https://user-images.githubusercontent.com/14993828/190074023-4ab8a4c6-94f0-4d46-a4a1-a7446b785998.png">
