### PR TITLE
Run CI on a recurring schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
+  schedule:
+    - cron: "3 2 1 * *"
 
 jobs:
   test:


### PR DESCRIPTION
https://github.com/zombocom/wicked/issues/299#issuecomment-1703210809

In addition to running on every push or pull request, the CI action will now run on a recurring schedule of once a month.

The schedule is set to run on the 1st of each month at 02:03 UTC time. The time is completely arbitrary but I avoided the top/bottom of the hour since most cron jobs tend to occur there.