### PR TITLE
remove redirect for setup wazard

### DIFF
--- a/lib/wicked/wizard.rb
+++ b/lib/wicked/wizard.rb
@@ -49,10 +49,17 @@ module Wicked
       @wicked_redirect_params = nil
     end
 
+    private def check_first_last_step!(step)
+      return steps.first if step.to_s == Wicked::FIRST_STEP
+      return steps.last if step.to_s == Wicked::LAST_STEP
+      return step
+    end
+
     private def setup_step_from(the_step)
       return if steps.nil?
 
       the_step ||= steps.first
+      the_step = check_first_last_step!(the_step)
 
       valid_steps = steps + self.class::PROTECTED_STEPS
       resolved_step = valid_steps.detect { |stp| stp.to_s == the_step }

--- a/lib/wicked/wizard.rb
+++ b/lib/wicked/wizard.rb
@@ -49,16 +49,10 @@ module Wicked
       @wicked_redirect_params = nil
     end
 
-    private def check_redirect_to_first_last!(step)
-      redirect_to wizard_path(steps.first) if step.to_s == Wicked::FIRST_STEP
-      redirect_to wizard_path(steps.last)  if step.to_s == Wicked::LAST_STEP
-    end
-
     private def setup_step_from(the_step)
       return if steps.nil?
 
       the_step ||= steps.first
-      check_redirect_to_first_last!(the_step)
 
       valid_steps = steps + self.class::PROTECTED_STEPS
       resolved_step = valid_steps.detect { |stp| stp.to_s == the_step }


### PR DESCRIPTION
Currently if we :set_steps with a route look like : flows_onboarding_user_path(**Wicked::FIRST_STEP**, new_business: "yes"). It'll redirect_to first_step and overwrite my :set_steps.

The problem is **Wicked::FIRST_STEP**, it'll work perfectly if I replace by the step_id

Below the code that I try to achieve : 

**CONTROLLER**
```
class Flows::OnboardingUserController < ApplicationController
  include Wicked::Wizard
  before_action :set_steps
  before_action :setup_wizard

  def show
     ...
  end

  def update
    ...
  end
  
   def set_steps
    if params[:steps]
      self.steps = params[:steps]
    elsif params[:new_business] == "yes"
      self.steps = [:platforms, :business_activity, :links, :reply]
    else
        self.steps = [:reply, :platforms, :business_activity, :company, :user]
    end
  end
end
```

**ROUTE**
`flows_onboarding_user_path(**Wicked::FIRST_STEP**, new_business: "yes")`






