### PR TITLE
Add Callback Support to render_wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add callback block to `render_wizard` for post-save actions (https://github.com/zombocom/wicked/pull/310)
+
 ## 2.0.0
 
 * Return `422` (`:unprocessable_entity`) when form submissions fails. Turbo requires an HTTP Status code between 400-499 or 500-599 when a FormSubmission request fails. This pull request makes wicked compatible with Turbo Drive (https://github.com/zombocom/wicked/pull/294)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ You can also pass a block to `render_wizard` that will be executed only when the
 ```ruby
 def update
   @user = current_user
-  @user.update(user_params)
+  @user.assign_attributes(user_params)
+
   render_wizard(@user) do
     # This block executes only if @user.save succeeds
     UserMailer.wizard_completed(@user).deliver_later

--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ We're passing `render_wizard` our `@user` object here. If you pass an object int
 
 Note that `render_wizard` does attempt to save the passed object. This means that in the above example, the object will be saved twice. This will cause any callbacks to run twice also. If this is undesirable for your use case, then calling `assign_attributes` (which does not save the object) instead of `update` might work better.
 
+You can also pass a block to `render_wizard` that will be executed only when the resource saves successfully:
+
+```ruby
+def update
+  @user = current_user
+  @user.update(user_params)
+  render_wizard(@user) do
+    # This block executes only if @user.save succeeds
+    UserMailer.wizard_completed(@user).deliver_later
+    Analytics.track(user: @user, event: 'wizard_step_completed')
+  end
+end
+```
+
+The callback is useful for triggering side effects like sending emails, logging analytics events, or updating related records only when the save is successful.
+
 To get to this update action, you simply need to submit a form that PUT's to the same url
 
 ```erb
@@ -205,6 +221,7 @@ jump_to(:specific_step)                       # Jump to :specific_step
 render_wizard                                 # Renders the current step
 render_wizard(@user)                          # Shows next_step if @user.save, otherwise renders
 render_wizard(@user, context: :account_setup) # Shows next_step if @user.save(context: :account_setup), otherwise renders
+render_wizard(@user) { ... }                  # Executes block only if @user.save succeeds
 wizard_steps                                  # Gets ordered list of steps
 current_step?(step)                           # is step the same as the current request's step
 past_step?(step)                              # does step come before the current request's step in wizard_steps

--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -1,8 +1,8 @@
 module Wicked::Controller::Concerns::RenderRedirect
   extend ActiveSupport::Concern
 
-  def render_wizard(resource = nil, options = {}, params = {})
-    process_resource!(resource, options)
+  def render_wizard(resource = nil, options = {}, params = {}, &)
+    process_resource!(resource, options, &)
 
     if @skip_to
       url_params = (@wicked_redirect_params || {}).merge(params)
@@ -12,7 +12,7 @@ module Wicked::Controller::Concerns::RenderRedirect
     end
   end
 
-  def process_resource!(resource, options = {})
+  def process_resource!(resource, options = {}, &)
     return unless resource
 
     if options[:context]
@@ -23,6 +23,8 @@ module Wicked::Controller::Concerns::RenderRedirect
 
     if did_save
       @skip_to ||= @next_step
+
+      yield if block_given?
     else
       @skip_to = nil
       # Do not override user-provided status for render

--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -2,9 +2,11 @@ module Wicked::Controller::Concerns::RenderRedirect
   extend ActiveSupport::Concern
 
   def render_wizard(resource = nil, options = {}, params = {}, &block)
-    process_resource!(resource, options, &block)
+    process_resource!(resource, options)
 
     if @skip_to
+      yield if block_given?
+
       url_params = (@wicked_redirect_params || {}).merge(params)
       redirect_to wizard_path(@skip_to, url_params), options
     else
@@ -12,7 +14,7 @@ module Wicked::Controller::Concerns::RenderRedirect
     end
   end
 
-  def process_resource!(resource, options = {}, &block)
+  def process_resource!(resource, options = {})
     return unless resource
 
     if options[:context]
@@ -23,8 +25,6 @@ module Wicked::Controller::Concerns::RenderRedirect
 
     if did_save
       @skip_to ||= @next_step
-
-      yield if block_given?
     else
       @skip_to = nil
       # Do not override user-provided status for render

--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -1,8 +1,8 @@
 module Wicked::Controller::Concerns::RenderRedirect
   extend ActiveSupport::Concern
 
-  def render_wizard(resource = nil, options = {}, params = {}, &)
-    process_resource!(resource, options, &)
+  def render_wizard(resource = nil, options = {}, params = {}, &block)
+    process_resource!(resource, options, &block)
 
     if @skip_to
       url_params = (@wicked_redirect_params || {}).merge(params)
@@ -12,7 +12,7 @@ module Wicked::Controller::Concerns::RenderRedirect
     end
   end
 
-  def process_resource!(resource, options = {}, &)
+  def process_resource!(resource, options = {}, &block)
     return unless resource
 
     if options[:context]

--- a/test/controllers/callbacks_controller_test.rb
+++ b/test/controllers/callbacks_controller_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class CallbacksControllerTest < WickedControllerTestCase
+  def setup
+    CallbacksController::CallbackCounter.reset
+  end
+
+  test 'callback is executed when resource saves successfully' do
+    put :update, params: { id: 'success_step' }
+
+    assert_equal 1, CallbacksController::CallbackCounter.count,
+                 'Expected callback to increment counter by 1 when save succeeds'
+    assert_response :redirect
+  end
+
+  test 'callback is not executed when resource fails to save' do
+    put :update, params: { id: 'failure_step' }
+
+    assert_equal 0, CallbacksController::CallbackCounter.count,
+                 'Expected callback NOT to increment counter when save fails'
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/dummy/app/controllers/callbacks_controller.rb
+++ b/test/dummy/app/controllers/callbacks_controller.rb
@@ -1,7 +1,6 @@
 class CallbacksController < ApplicationController
   include Wicked::Wizard
 
-  # Class-level counter to track callback execution
   class CallbackCounter
     @@count = 0
 
@@ -25,7 +24,6 @@ class CallbacksController < ApplicationController
   end
 
   def update
-    # Determine success/failure based on step
     value = case step
             when :success_step
               true
@@ -35,7 +33,7 @@ class CallbacksController < ApplicationController
 
     @bar = Bar.new(value)
 
-    render_wizard(@bar, notice: "Update attempted for #{step}.") do
+    render_wizard(@bar) do
       CallbackCounter.increment
     end
   end

--- a/test/dummy/app/controllers/callbacks_controller.rb
+++ b/test/dummy/app/controllers/callbacks_controller.rb
@@ -1,0 +1,48 @@
+class CallbacksController < ApplicationController
+  include Wicked::Wizard
+
+  # Class-level counter to track callback execution
+  class CallbackCounter
+    @@count = 0
+
+    def self.increment
+      @@count += 1
+    end
+
+    def self.count
+      @@count
+    end
+
+    def self.reset
+      @@count = 0
+    end
+  end
+
+  steps :success_step, :failure_step
+
+  def show
+    render_wizard
+  end
+
+  def update
+    # Determine success/failure based on step
+    value = case step
+            when :success_step
+              true
+            when :failure_step
+              false
+            end
+
+    @bar = Bar.new(value)
+
+    render_wizard(@bar, notice: "Update attempted for #{step}.") do
+      CallbackCounter.increment
+    end
+  end
+
+  private
+
+  def finish_wizard_path
+    root_path
+  end
+end

--- a/test/dummy/app/views/callbacks/failure_step.html.erb
+++ b/test/dummy/app/views/callbacks/failure_step.html.erb
@@ -1,0 +1,2 @@
+<h1>Failure Step</h1>
+<p>This resource will fail to save (value = false).</p>

--- a/test/dummy/app/views/callbacks/success_step.html.erb
+++ b/test/dummy/app/views/callbacks/success_step.html.erb
@@ -1,0 +1,2 @@
+<h1>Success Step</h1>
+<p>This resource will save successfully (value = true).</p>

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -15,7 +15,7 @@ Dummy::Application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = Rails::VERSION::MAJOR >= 7 && Rails::VERSION::MINOR >= 1 ? :none : false
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -11,6 +11,7 @@ Dummy::Application.routes.draw do
   resources :status_codes
   resources :updates
   resources :update_params
+  resources :callbacks
 
   resources :nested do
     resources :builder, :controller => 'nested/builder'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,8 @@ if ActiveRecord.version < Gem::Version.create("5.2.0")
   ActiveRecord::Migrator.migrate(migrate_path)
 elsif ActiveRecord.version < Gem::Version.create("6.0.0")
   ActiveRecord::MigrationContext.new(migrate_path).migrate
+elsif ActiveRecord.version >= Gem::Version.create("7.1.0")
+  ActiveRecord::MigrationContext.new(migrate_path).migrate
 else
   ActiveRecord::MigrationContext.new(migrate_path, ActiveRecord::SchemaMigration).migrate
 end


### PR DESCRIPTION
This PR addresses #277.

## Summary

Added the ability to execute callbacks when render_wizard saves a record successfully. The callback block is only executed when did_save = true, allowing users to trigger side effects like sending emails, logging analytics, or updating related records only on successful saves.

## Usage Example
```ruby
def update
  @user = current_user
  @user.assign_attributes(user_params)

  render_wizard(@user) do
    # This block executes only if @user.save succeeds
    UserMailer.wizard_completed(@user).deliver_later
    Analytics.track(user: @user, event: 'wizard_step_completed')
  end
end
```

Backwards Compatibility
✅ Fully backwards compatible - block parameter is optional, existing code works unchanged.

## Test Fixes

Fixed 3 failing integration tests that were broken in Rails 7.1+ due to breaking changes in Rails configuration APIs:

*Issues Identified*
1. Migration API Change (Rails 7.1+)
   - Rails 7.1 reverted ActiveRecord::MigrationContext to a simpler API without the SchemaMigration parameter
   - Old tests were failing with NoMethodError: undefined method 'create_table'
2. Exception Handling Change (Rails 7.1+)  
   - Rails 7.1 changed config.action_dispatch.show_exceptions from boolean (true/false) to symbols (:all, :rescuable, :none)
   - Deprecated false value was being treated as :rescuable (new default)
   - Custom exceptions like Wicked::Wizard::InvalidStepError were no longer being raised in tests, causing assert_raise failures

**NOTES: There are still issues with Ruby 2.5, 2.6 and 2.7 with Rails 6.0 that I did not address. Hopefully we can still get this merged since those are unrelated to my changes**